### PR TITLE
Migrating To Go Modules

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,6 +1,0 @@
-hash: c927181c2fe8c45a689ca23ad2552eb27980060ab125b41b979a17e677f1ddbd
-updated: 2016-08-28T22:00:45.246106868+10:00
-imports:
-- name: github.com/gorilla/websocket
-  version: 1f512fc3f05332ba7117626cdfb4e07474e58e60
-testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,4 +1,0 @@
-package: github.com/jmalloc/echo-server
-import:
-- package: github.com/gorilla/websocket
-  version: ^1.0.0

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/jmalloc/echo-server
+
+go 1.14
+
+require (
+	github.com/gorilla/websocket v1.0.0
+	golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,9 @@
+github.com/gorilla/websocket v1.0.0 h1:J/mA+d2LqcDKjAEhQjXDHt9/e7Cnm+oBUwgHp5C6XDg=
+github.com/gorilla/websocket v1.0.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e h1:3G+cUijn7XD+S4eJFddp53Pv7+slrESplyjG25HgL+k=
+golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
- Removed traces of glide from Makefile.
- Go 1.10+ supports single coverage file, Separate coverage profiles are no longer needed, so removed `gocovmerge` - https://golang.org/doc/go1.10#test

Related issue - https://github.com/jmalloc/echo-server/issues/6