### PR TITLE
Add a route that sends "server-sent events".

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ The format is based on [Keep a Changelog], and this project adheres to
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
+## [Unreleased]
+
+- Add the `/.see` route
+
 ## [0.2.0] - 2021-06-03
 
 - Add support for logging HTTP headers to stdout (thanks [@arulrajnet])

--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
 # Echo Server
 
-A very simple HTTP echo server with support for websockets.
+A very simple HTTP echo server with support for websockets and server-sent
+events (SSE).
 
 ## Behavior
 
 - Any messages sent from a websocket client are echoed
 - Visit `/.ws` for a basic UI to connect and send websocket messages
+- Request `/.sse` to receive a server-sent events containing the request headers
+  and body, then a counter message every second
 - Requests to any other URL will return the request headers and body
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -3,13 +3,15 @@
 A very simple HTTP echo server with support for websockets and server-sent
 events (SSE).
 
+The server is designed for testing HTTP proxies and clients. It echoes
+information about HTTP request headers and bodies back to the client.
+
 ## Behavior
 
-- Any messages sent from a websocket client are echoed
-- Visit `/.ws` for a basic UI to connect and send websocket messages
-- Request `/.sse` to receive a server-sent events containing the request headers
-  and body, then a counter message every second
-- Requests to any other URL will return the request headers and body
+- Any messages sent from a websocket client are echoed as a websocket message
+- Visit `/.ws` in a browser for a basic UI to connect and send websocket messages
+- Request `/.sse` to receive the echo response via server-sent events
+- Request any other URL to receive the echo response in plain text
 
 ## Configuration
 

--- a/cmd/echo-server/main.go
+++ b/cmd/echo-server/main.go
@@ -252,6 +252,6 @@ func writeRequest(w io.Writer, req *http.Request) {
 
 	if body.Len() > 0 {
 		fmt.Fprintln(w, "")
-		body.WriteTo(w)
+		body.WriteTo(w) // nolint:errcheck
 	}
 }


### PR DESCRIPTION
This PR adds the `/.sse` route which echos the HTTP request details back using server-sent events, it then sends an event containing the current timestamp once per second.