### PR TITLE
Add option to suppress sending server hostname in responses.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ The format is based on [Keep a Changelog], and this project adheres to
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
+## [Unreleased]
+
+### Added
+
+- Add the `SEND_SERVER_HOSTNAME` environment variable
+- Add the `X-Send-Server-Hostname` request header
+
 ## [0.3.0] - 2021-08-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -8,16 +8,20 @@ information about HTTP request headers and bodies back to the client.
 
 ## Behavior
 
-- Any messages sent from a websocket client are echoed as a websocket message
-- Visit `/.ws` in a browser for a basic UI to connect and send websocket messages
-- Request `/.sse` to receive the echo response via server-sent events
-- Request any other URL to receive the echo response in plain text
+- Any messages sent from a websocket client are echoed as a websocket message.
+- Visit `/.ws` in a browser for a basic UI to connect and send websocket messages.
+- Request `/.sse` to receive the echo response via server-sent events.
+- Request any other URL to receive the echo response in plain text.
 
 ## Configuration
 
-- The `PORT` environment variable sets the server port, which defaults to `8080`
-- Set the `LOG_HTTP_BODY` environment variable to dump request bodies to `STDOUT`
-- Set the `LOG_HTTP_HEADERS` environment variable to dump request headers to `STDOUT`
+- The `PORT` environment variable sets the server port, which defaults to `8080`.
+- Set the `LOG_HTTP_BODY` environment variable to dump request bodies to `STDOUT`.
+- Set the `LOG_HTTP_HEADERS` environment variable to dump request headers to `STDOUT`.
+- Set the `SEND_SERVER_HOSTNAME` environment variable to `false` to prevent the
+  server from responding with its hostname before echoing the request. The
+  client may send the `X-Send-Server-Hostname` request header to `true` or
+  `false` to override this server-wide setting on a per-request basis.
 
 ## Running the server
 


### PR DESCRIPTION
This PR adds support for a new environment variable, `SEND_SERVER_HOSTNAME`. When set to `false` it prevents the server from sending its hostname before echoing the response. This applies to websocket and SSE requests as well. The default behavior remains the same.

Also added support for an `X-Send-Server-Hostname` header to override this on a per-request basis.

Fixes #18 