### PR TITLE
Serve .ws and .sse endpoints from any path.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog], and this project adheres to
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/
 [semantic versioning]: https://semver.org/spec/v2.0.0.html
 
+## [Unreleased]
+
+- Serve the `.ws` and `.sse` endpoints from any directory
+
 ## [0.3.6] - 2023-10-31
 
 - Add support for sending arbitrary headers in all responses

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ DOCKER_REPO = jmalloc/echo-server
 DOCKER_PLATFORMS += linux/amd64
 DOCKER_PLATFORMS += linux/arm64
 
+GO_EMBEDDED_FILES += cmd/echo-server/html/frontend.tmpl.html
+
 -include .makefiles/Makefile
 -include .makefiles/pkg/go/v1/Makefile
 -include .makefiles/pkg/docker/v1/Makefile

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ information about HTTP request headers and bodies back to the client.
 ## Behavior
 
 - Any messages sent from a websocket client are echoed as a websocket message.
-- Visit `/.ws` in a browser for a basic UI to connect and send websocket messages.
-- Request `/.sse` to receive the echo response via server-sent events.
+- Requests to a file named `.ws` under any path serve a basic UI to connect and send websocket messages.
+- Requests to a file named `.sse` under any path streams server-sent events.
 - Request any other URL to receive the echo response in plain text.
 
 ## Configuration
@@ -44,11 +44,6 @@ SEND_HEADER_ACCESS_CONTROL_ALLOW_ORIGIN="*"
 SEND_HEADER_ACCESS_CONTROL_ALLOW_METHODS="*"
 SEND_HEADER_ACCESS_CONTROL_ALLOW_HEADERS="*"
 ```
-
-### Web Socket Test Path 
-
-Set the `FRONTEND_WS_PATH` environment variable to send web socket request to the particular path 
-instead of root
 
 ## Running the server
 

--- a/cmd/echo-server/html/frontend.tmpl.html
+++ b/cmd/echo-server/html/frontend.tmpl.html
@@ -128,7 +128,9 @@
             }
 
             function connect() {
-                log('attempting to connect', 'info')
+                url = (location.protocol === 'https:' ? 'wss' : 'ws') + '://' + window.location.host + '{{.Path}}';
+
+                log('attempting to connect to ' + url, 'info')
 
                 autoReconnect = true;
                 msgPanel.className = 'hidden';
@@ -138,11 +140,7 @@
                 disconnectBtn.className = 'hidden';
                 cancelBtn.className = '';
 
-                ws = new WebSocket(
-                    (location.protocol === 'https:'
-                        ? 'wss://' + window.location.host
-                        : 'ws://' + window.location.host) + '{{.Path}}'
-                );
+                ws = new WebSocket(url);
 
                 ws.onopen = function (ev) {
                     msgPanel.className = '';

--- a/cmd/echo-server/main.go
+++ b/cmd/echo-server/main.go
@@ -173,7 +173,10 @@ func serveFrontend(wr http.ResponseWriter, req *http.Request) {
 	templateData := struct {
 		Path string
 	}{
-		Path: path.Dir(req.URL.Path),
+		Path: path.Join(
+			os.Getenv("WEBSOCKET_ROOT"),
+			path.Dir(req.URL.Path),
+		),
 	}
 	err = tmpl.Execute(wr, templateData)
 	if err != nil {


### PR DESCRIPTION
This PR changes the server to host the websocket UI under any path when the `.ws` filename is requested. Likewise it will stream server-sent events from any path preceding the `.sse` filename.

The websocket UI has also been updated to open the websocket connection at the same directory as the `.ws` file.